### PR TITLE
Create a copy of keys to avoid undefined behavior

### DIFF
--- a/gl/scene/scene_graph.h
+++ b/gl/scene/scene_graph.h
@@ -83,6 +83,8 @@ class SceneGraph {
     inline void AddChildKey(Key key) { children_keys_.emplace(key); }
     /// Erase a child key from the node.
     inline int EraseChildKey(Key key) { return children_keys_.erase(key); }
+    /// Erase all children from the node.
+    inline void ClearChildKeys() noexcept { children_keys_.clear(); }
 
     /// Draw this node at the correct position in the world.
     void Draw(const Eigen::Isometry3f& tx_accumulated =
@@ -103,20 +105,32 @@ class SceneGraph {
 
    private:
     /// Key of this node.
-    Key key_;
+    Key key_{};
     /// A key of a direct parent of this node.
-    Key parent_key_;
+    Key parent_key_{};
     /// Keys of all children of this node.
-    std::set<Key> children_keys_;
+    std::set<Key> children_keys_{};
 
     /// Relative transformation from this coordinate frame to parent's one.
-    Eigen::Isometry3f tx_parent_local_;
+    Eigen::Isometry3f tx_parent_local_{};
 
     /// Every node is storing a drawable.
-    Drawable::SharedPtr drawable_ = nullptr;
+    Drawable::SharedPtr drawable_{};
 
-    /// They nodes are stored elsewhere. We need the pointer to this place.
-    SceneGraph::Storage<Node::UniquePtr>* storage_ = nullptr;
+    /// The nodes are stored elsewhere. We need the pointer to this place.
+    SceneGraph::Storage<Node::UniquePtr>* storage_{};
+  };
+
+  /// This is a view of the storage that helps correctly erasing nodes.
+  class NodeEraser {
+   public:
+    explicit NodeEraser(SceneGraph::Storage<Node::UniquePtr>* storage);
+    int Erase(Key node);
+    int EraseChildren(Key node);
+
+   private:
+    void FindRecursiveChildren(Key key, std::set<Key>* children);
+    SceneGraph::Storage<Node::UniquePtr>* storage_{};
   };
 
   static const Key kRootKey;

--- a/gl/scene/scene_graph_test.cpp
+++ b/gl/scene/scene_graph_test.cpp
@@ -23,7 +23,7 @@ TEST(SceneGraphTest, ForgetInit) {
   EXPECT_DEATH(
       graph.SceneGraph::Attach(
           world_key, std::make_shared<Drawable>(Drawable::Style::DRAW_3D)),
-      "Must have a real parent");
+      "New node must have a parent");
 }
 
 TEST(SceneGraphTest, StoringDrawable) {

--- a/gl/scene/scene_graph_test.cpp
+++ b/gl/scene/scene_graph_test.cpp
@@ -112,7 +112,7 @@ TEST(SceneGraphTest, SimpleEraseChildren) {
   EXPECT_TRUE(graph.HasNode(key_3));
   EXPECT_TRUE(graph.HasNode(key_4));
   EXPECT_TRUE(graph.HasNode(key_5));
-  graph.EraseChildren(key_1);
+  EXPECT_EQ(3, graph.EraseChildren(key_1));
   EXPECT_EQ(graph.size(), 3u);
   EXPECT_TRUE(graph.HasNode(key_1));
   EXPECT_TRUE(graph.HasNode(key_2));


### PR DESCRIPTION
This was a fun bug to solve. `Erase` method would change the underlying container in the for loop of the `EraseChildren` method, thus invalidating the iterators and causing undefined behavior. This PR fixes this.